### PR TITLE
deps: bump twilight to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.1.0"
 
 [dependencies]
 tracing = { default-features = false, optional = true, version = "0.1" }
-twilight-model = { default-features = false, version = "0.3" }
+twilight-model = { default-features = false, version = "0.4" }
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.3" }


### PR DESCRIPTION
bench fails but it did so before too 🤷

Signed-off-by: Vilgot Fredenberg <vilgot@fredenberg.xyz>